### PR TITLE
subctl verify shouldn’t randomize test order

### DIFF
--- a/cmd/subctl/verify.go
+++ b/cmd/subctl/verify.go
@@ -288,6 +288,7 @@ func runVerify(
 
 	suiteConfig, reporterConfig := ginkgo.GinkgoConfiguration()
 	suiteConfig.FocusStrings = patterns
+	suiteConfig.RandomSeed = 1
 	reporterConfig.Verbose = verboseConnectivityVerification
 	reporterConfig.JUnitReport = junitReport
 	framework.TestContext.SuiteConfig = &suiteConfig


### PR DESCRIPTION
Ginkgo automatically randomizes the order of top-level containers. While this isn't configurable, we can set the random seed to a hard-coded number to effect deterministic behavior.

Signed-off-by: Tom Pantelis <tompantelis@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
