### PR TITLE
Add --extracontext arg to subctl verify

### DIFF
--- a/.github/workflows/system.yml
+++ b/.github/workflows/system.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        using: ['', 'globalnet lighthouse']
+        using: ['', 'globalnet', 'lighthouse']
     steps:
       - name: Check out the repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11

--- a/.shipyard.lighthouse.yml
+++ b/.shipyard.lighthouse.yml
@@ -1,0 +1,7 @@
+---
+submariner: true
+nodes: control-plane
+clusters:
+  cluster1:
+  cluster2:
+  cluster3:

--- a/cmd/subctl/verify.go
+++ b/cmd/subctl/verify.go
@@ -62,18 +62,21 @@ var (
 
 var verifyRestConfigProducer = restconfig.NewProducer().
 	WithPrefixedContext("to").
+	WithPrefixedContext("extra").
 	WithDefaultNamespace(constants.OperatorNamespace)
 
 var verifyCmd = &cobra.Command{
-	Use:   "verify --context <kubeContext1> --tocontext <kubeContext2>",
+	Use:   "verify --context <kubeContext1> --tocontext <kubeContext2> [--extracontext <kubeContext3>]",
 	Short: "Run verifications between two clusters",
-	Long: `This command performs various tests to verify that a Submariner deployment between two clusters
-is functioning properly. The verifications performed are controlled by the --only and --enable-disruptive
-flags. All verifications listed in --only are performed with special handling for those deemed as disruptive.
-A disruptive verification is one that changes the state of the clusters as a side effect. If running the
-command interactively, you will be prompted for confirmation to perform disruptive verifications unless
-the --enable-disruptive flag is also specified. If running non-interactively (that is with no stdin),
---enable-disruptive must be specified otherwise disruptive verifications are skipped.
+	Long: `This command performs various tests to verify that a Submariner deployment between two clusters,
+specified via the --context and --tocontext args, is functioning properly. Some tests require a third cluster,
+specified via the --extracontext arg, to verify additional functionality. If the third cluster is not specified,
+those tests are skipped. The verifications performed are controlled by the --only and --enable-disruptive flags.
+All verifications listed in --only are performed with special handling for those deemed as disruptive. A disruptive
+verification is one that changes the state of the clusters as a side effect. If running the command interactively,
+you will be prompted for confirmation to perform disruptive verifications unless the --enable-disruptive flag is
+also specified. If running non-interactively (that is with no stdin), --enable-disruptive must be specified otherwise
+disruptive verifications are skipped.
 
 The following verifications are deemed disruptive:
 
@@ -86,7 +89,16 @@ The following verifications are deemed disruptive:
 				toContextPresent, err := verifyRestConfigProducer.RunOnSelectedPrefixedContext(
 					"to",
 					func(toClusterInfo *cluster.Info, _ string, status reporter.Interface) error {
-						return runVerify(fromClusterInfo, toClusterInfo, namespace, determineSpecLabelsToVerify())
+						extraContextPresent, err := verifyRestConfigProducer.RunOnSelectedPrefixedContext(
+							"extra",
+							func(extraClusterInfo *cluster.Info, _ string, status reporter.Interface) error {
+								return runVerify(fromClusterInfo, toClusterInfo, extraClusterInfo, namespace, determineSpecLabelsToVerify())
+							}, status)
+						if extraContextPresent {
+							return err //nolint:wrapcheck // No need to wrap errors here.
+						}
+
+						return runVerify(fromClusterInfo, toClusterInfo, nil, namespace, determineSpecLabelsToVerify())
 					}, status)
 
 				if toContextPresent {
@@ -283,10 +295,16 @@ prompt for confirmation therefore you must specify --enable-disruptive to run th
 	return labels
 }
 
-func runVerify(fromClusterInfo, toClusterInfo *cluster.Info, namespace string, specLabels []string) error {
+func runVerify(fromClusterInfo, toClusterInfo, extraClusterInfo *cluster.Info, namespace string, specLabels []string) error {
 	framework.RestConfigs = []*rest.Config{fromClusterInfo.RestConfig, toClusterInfo.RestConfig}
 	framework.TestContext.ClusterIDs = []string{fromClusterInfo.Name, toClusterInfo.Name}
 	framework.TestContext.KubeContexts = []string{fromClusterInfo.Name, toClusterInfo.Name}
+
+	if extraClusterInfo != nil {
+		framework.RestConfigs = append(framework.RestConfigs, extraClusterInfo.RestConfig)
+		framework.TestContext.ClusterIDs = append(framework.TestContext.ClusterIDs, extraClusterInfo.Name)
+		framework.TestContext.KubeContexts = append(framework.TestContext.KubeContexts, extraClusterInfo.Name)
+	}
 
 	framework.TestContext.OperationTimeout = operationTimeout
 	framework.TestContext.ConnectionTimeout = connectionTimeout

--- a/scripts/test/system.sh
+++ b/scripts/test/system.sh
@@ -148,6 +148,13 @@ function validate_and_clean_broker_info() {
 
 subm_ns=submariner-operator
 submariner_broker_ns=submariner-k8s-broker
+
+if [[ "${LIGHTHOUSE}" != true ]]; then
+  SETTINGS="$DAPPER_SOURCE"/.shipyard.system.yml
+else
+  SETTINGS="$DAPPER_SOURCE"/.shipyard.lighthouse.yml
+fi
+
 load_settings
 declare_kubeconfig
 deploy_env_once
@@ -156,7 +163,8 @@ deploy_env_once
 
 # Test subctl show invocations
 
-_subctl show all | tee /dev/stderr | (sponge ||:) | grep -q 'Cluster "cluster2"'
+# Some clusters may not be connected yet so retry
+with_retries 30 sleep_on_fail 1s _subctl show all | tee /dev/stderr | (sponge ||:) | grep -q 'Cluster "cluster2"'
 # Single-context variants don't say 'Cluster "foo"', check what cluster is considered local
 _subctl show all --context cluster1 | tee /dev/stderr | (sponge ||:) | grep -qv 'cluster2.*local'
 _subctl show all --context cluster2 | tee /dev/stderr | (sponge ||:) | grep -q 'cluster2.*local'
@@ -186,27 +194,31 @@ with_context "${clusters[0]}" test_subctl_diagnose_in_cluster
 
 # Test subctl benchmark invocations
 
-_subctl benchmark latency --context cluster1 | tee /dev/stderr | (sponge ||:) | grep -q 'Performing latency tests from Non-Gateway pod to Gateway pod on cluster "cluster1"'
-_subctl benchmark latency --context cluster1 --tocontext cluster2 | tee /dev/stderr | (sponge ||:) | grep -qE '(Performing latency tests from Gateway pod on cluster "cluster1" to Gateway pod on cluster "cluster2"|Latency test is not supported with Globalnet enabled, skipping the test)'
+if [[ "${LIGHTHOUSE}" != true ]]; then
+  _subctl benchmark latency --context cluster1 | tee /dev/stderr | (sponge ||:) | grep -q 'Performing latency tests from Non-Gateway pod to Gateway pod on cluster "cluster1"'
+  _subctl benchmark latency --context cluster1 --tocontext cluster2 | tee /dev/stderr | (sponge ||:) | grep -qE '(Performing latency tests from Gateway pod on cluster "cluster1" to Gateway pod on cluster "cluster2"|Latency test is not supported with Globalnet enabled, skipping the test)'
 
-_subctl benchmark throughput --context cluster1 | tee /dev/stderr | (sponge ||:) | grep -q 'Performing throughput tests from Non-Gateway pod to Gateway pod on cluster "cluster1"'
-_subctl benchmark throughput --context cluster1 --tocontext cluster2
+  _subctl benchmark throughput --context cluster1 | tee /dev/stderr | (sponge ||:) | grep -q 'Performing throughput tests from Non-Gateway pod to Gateway pod on cluster "cluster1"'
+  _subctl benchmark throughput --context cluster1 --tocontext cluster2
 
-# Obsolete variant with contexts
-_subctl benchmark latency --intra-cluster --kubecontexts cluster1 && exit 1
-_subctl benchmark latency --kubecontexts cluster1,cluster2 && exit 1
+  # Obsolete variant with contexts
+  _subctl benchmark latency --intra-cluster --kubecontexts cluster1 && exit 1
+  _subctl benchmark latency --kubecontexts cluster1,cluster2 && exit 1
 
-_subctl benchmark throughput --intra-cluster --kubecontexts cluster1 && exit 1
-_subctl benchmark throughput --kubecontexts cluster1,cluster2 && exit 1
+  _subctl benchmark throughput --intra-cluster --kubecontexts cluster1 && exit 1
+  _subctl benchmark throughput --kubecontexts cluster1,cluster2 && exit 1
 
-# Obsolete variant with kubeconfigs
-_subctl benchmark latency "${KUBECONFIGS_DIR}"/kind-config-cluster1 "${KUBECONFIGS_DIR}"/kind-config-cluster2 && exit 1
+  # Obsolete variant with kubeconfigs
+  _subctl benchmark latency "${KUBECONFIGS_DIR}"/kind-config-cluster1 "${KUBECONFIGS_DIR}"/kind-config-cluster2 && exit 1
 
-_subctl benchmark throughput "${KUBECONFIGS_DIR}"/kind-config-cluster1 "${KUBECONFIGS_DIR}"/kind-config-cluster2 && exit 1
+  _subctl benchmark throughput "${KUBECONFIGS_DIR}"/kind-config-cluster1 "${KUBECONFIGS_DIR}"/kind-config-cluster2 && exit 1
 
-# Test subctl verify basic
+  # Test subctl verify basic
 
-_subctl verify --context cluster1 --tocontext cluster2 --only basic-connectivity --verbose
+  _subctl verify --context cluster1 --tocontext cluster2 --only basic-connectivity --verbose
+else
+  _subctl verify --context cluster1 --tocontext cluster2 --extracontext cluster3 --only service-discovery --verbose
+fi
 
 # Test subctl cloud prepare invocations
 


### PR DESCRIPTION
...to run lighthouse tests that require a third cluster.

Fixes https://github.com/submariner-io/subctl/issues/276

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
