### PR TITLE
Enable leader election in the operator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/submariner-io/lighthouse v0.20.0-m1
 	github.com/submariner-io/shipyard v0.20.0-m1
 	github.com/submariner-io/submariner v0.20.0-m1
-	github.com/submariner-io/submariner-operator v0.20.0-m1
+	github.com/submariner-io/submariner-operator v0.20.0-m1.0.20241210155444-c041b74cd56a
 	github.com/uw-labs/lichen v0.1.7
 	golang.org/x/net v0.32.0
 	golang.org/x/oauth2 v0.24.0

--- a/go.sum
+++ b/go.sum
@@ -537,8 +537,8 @@ github.com/submariner-io/shipyard v0.20.0-m1 h1:A1QooNpKyD69GqcfTjl5/ToSAGKQSxVy
 github.com/submariner-io/shipyard v0.20.0-m1/go.mod h1:v+gjhwiIoKl2OjKPwfkFT9MwIGKc0LR3nSI7X6G14TY=
 github.com/submariner-io/submariner v0.20.0-m1 h1:dHARUVZAcJE6khJdfeSf103d2C8Wp8jslfITY0qt4kg=
 github.com/submariner-io/submariner v0.20.0-m1/go.mod h1:EvB5MhIsn3QelCKmN3XLLdt9Pm7K/bMwcbqdIu8oqZ8=
-github.com/submariner-io/submariner-operator v0.20.0-m1 h1:Gb3MPxFNmk8hA36Jkcd140LdjXGWpN4Pv8ETBYJcf3E=
-github.com/submariner-io/submariner-operator v0.20.0-m1/go.mod h1:fwfYRk6Dy3mjdUvyQJAYuJgSY+4I4LabXuC7FakinMs=
+github.com/submariner-io/submariner-operator v0.20.0-m1.0.20241210155444-c041b74cd56a h1:ew4/o2PN+Jp+X85CcMwiIqrQqxYB+YjTWMMwX1Oljik=
+github.com/submariner-io/submariner-operator v0.20.0-m1.0.20241210155444-c041b74cd56a/go.mod h1:z/U6J/Lk9Nhdg9OSv8XgG689DipD/uubAYaeFWlt6Is=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/pkg/operator/deployment/ensure.go
+++ b/pkg/operator/deployment/ensure.go
@@ -47,11 +47,11 @@ func Ensure(ctx context.Context, kubeClient kubernetes.Interface, namespace, ima
 		imagePullPolicy = v1.PullIfNotPresent
 	}
 
-	command := []string{operatorName}
+	args := []string{"--leader-elect"}
 	if debug {
-		command = append(command, "-v=3")
+		args = append(args, "-v=3")
 	} else {
-		command = append(command, "-v=1")
+		args = append(args, "-v=1")
 	}
 
 	opDeployment := &appsv1.Deployment{
@@ -72,7 +72,8 @@ func Ensure(ctx context.Context, kubeClient kubernetes.Interface, namespace, ima
 						{
 							Name:            operatorName,
 							Image:           image,
-							Command:         command,
+							Command:         []string{operatorName},
+							Args:            args,
 							ImagePullPolicy: imagePullPolicy,
 							SecurityContext: &v1.SecurityContext{
 								RunAsNonRoot:             ptr.To(true),


### PR DESCRIPTION
The operator no longer runs leader-for-life election so enable leader-with-lease via the CLI arg in the pod spec.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our developer guide: https://submariner.io/development/
2. Ensure you have added the appropriate tests for your PR: https://submariner.io/development/code-review/#test-new-functionality
3. Read the code review guide to ease the review process: https://submariner.io/development/code-review/
4. If the PR is unfinished, mark it as a draft: https://submariner.io/development/code-review/#mark-work-in-progress-prs-as-drafts
5. If you are using CI to debug, use your private fork: https://submariner.io/development/code-review/#use-private-forks-for-debugging-prs-by-running-ci
6. Add labels to the PR as appropriate.

This template is based on the K8s/K8s template:

https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
